### PR TITLE
Potential fix for code scanning alert no. 30: XML internal entity expansion

### DIFF
--- a/core/appHandler.js
+++ b/core/appHandler.js
@@ -232,7 +232,7 @@ module.exports.bulkProductsLegacy = function (req,res){
 
 module.exports.bulkProducts =  function(req, res) {
 	if (req.files.products && req.files.products.mimetype=='text/xml'){
-		var products = libxmljs.parseXmlString(req.files.products.data.toString('utf8'), {noent:true,noblanks:true})
+		var products = libxmljs.parseXmlString(req.files.products.data.toString('utf8'), {noblanks:true})
 		products.root().childNodes().forEach( product => {
 			var newProduct = new db.Product()
 			newProduct.name = product.childNodes()[0].text()


### PR DESCRIPTION
Potential fix for [https://github.com/FPL-Code/dvna/security/code-scanning/30](https://github.com/FPL-Code/dvna/security/code-scanning/30)

To fix the problem, we need to disable entity expansion when parsing the XML data. This can be achieved by removing the `{noent: true}` option from the `libxmljs.parseXmlString` method call. This will prevent the parser from expanding entities, thus mitigating the risk of XML bomb attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
